### PR TITLE
Fix: [base-music/524f5454] fixed broken upload in storage; size slightly changed

### DIFF
--- a/base-music/524f5454/versions/20200728T110419Z.yaml
+++ b/base-music/524f5454/versions/20200728T110419Z.yaml
@@ -2,7 +2,7 @@ version: "1.0"
 license: "Custom"
 upload-date: 2020-07-28T11:04:19Z
 md5sum-partial: "e99a2457"
-filesize: 112548
+filesize: 112590
 availability: "new-games"
 compatibility:
 - name: "master"


### PR DESCRIPTION
See https://github.com/OpenTTD/bananas-api/issues/59 for more
details on what was broken and what is fixed. Normally we do not
change these things for users, but this was a bug in BaNaNaS,
with a trivial way to fix it for the user. Hence this route.