### PR TITLE
Fix: Remove English part of description for Chinese townnames GRF

### DIFF
--- a/newgrf/5a425801/global.yaml
+++ b/newgrf/5a425801/global.yaml
@@ -6,13 +6,6 @@ description: |-
 
   制作: Zbx1425
   网站: www.zbx1425.tk
-
-  Includes true chinese town names.
-  City names are from the claimed administrative division of P.R. China at the time of 2019.
-  The author has no intention of raising political arguments. Please choose other newGRFs if you disagree with the administrative division included in this newGRF.
-
-  Made by Zbx1425
-  My website: www.zbx1425.tk
 url: "https://www.zbx1425.tk"
 tags:
 - "chinese"

--- a/newgrf/5a425801/versions/20190521T104220Z.yaml
+++ b/newgrf/5a425801/versions/20190521T104220Z.yaml
@@ -16,10 +16,3 @@ description: |-
 
   制作: Zbx1425
   网站: www.zbx1425.tk
-
-  Includes true chinese town names.
-  City names are from the claimed administrative division of P.R. China at the time of 2019.
-  The author respects your political view and has no intention of raising associated arguments. Please choose other newGRFs if you disagree with the administrative division presented in this newGRF.
-
-  Made by Zbx1425
-  My website: www.zbx1425.tk


### PR DESCRIPTION
To bring it under the length limit of 511, due to incoming better validation of text lengths (OpenTTD/bananas-api#80)

English part removed since the townnames are in Chinese, you're unlikely to want them unless you can read Chinese.

@zbx1425 's Chinese True Town Names
