### PR TITLE
Add: DorpsGek config file

### DIFF
--- a/.dorpsgek.yml
+++ b/.dorpsgek.yml
@@ -1,0 +1,8 @@
+notifications:
+  global:
+    irc:
+    - openttd
+    - openttd.notice
+
+  pull-request:
+  issue:


### PR DESCRIPTION
Left out `tag-created:`, as this repo doesn't have tags