### PR TITLE
Fix: newgrf/44450601 versions uploaded in the wrong order

### DIFF
--- a/newgrf/44450601/versions/20210214T182614Z.yaml
+++ b/newgrf/44450601/versions/20210214T182614Z.yaml
@@ -3,7 +3,7 @@ license: "GPL v2"
 upload-date: 2021-02-14T18:26:14Z
 md5sum-partial: "f81ae7e9"
 filesize: 261635
-availability: "savegames-only"
+availability: "new-games"
 compatibility:
 - name: "master"
   conditions:

--- a/newgrf/44450601/versions/20210214T182923Z.yaml
+++ b/newgrf/44450601/versions/20210214T182923Z.yaml
@@ -3,21 +3,8 @@ license: "GPL v2"
 upload-date: 2021-02-14T18:29:23Z
 md5sum-partial: "1a15fdc9"
 filesize: 226651
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "master"
   conditions:
   - ">= 1.7.0"
-
-name: "Unspooled"
-description: "Unspool some cable and hang a lovely mess of trolley (and trolleybus) wire over a selection of road and tram types! New hand-drawn trolleywire and poles, with road sprites adapted from OpenGFX & ARRS. Several distinct trolleybus and tramway wire types, as well as various road types."
-url: "https://www.tt-forums.net/viewtopic.php?f=26&t=75986"
-tags:
-- "Mop"
-- "NRT"
-- "Roads"
-- "Roadtype"
-- "Tramtype"
-- "Tramway"
-- "Trolley"
-- "Trolleybus"


### PR DESCRIPTION
supermop uploaded version 0.3.2 after version 0.4.2, causing an availability inversion