### PR TITLE
Fix: [Actions] "unbreak" reload workflows by downgrading to Ubuntu 18.04

### DIFF
--- a/.github/workflows/reload_api.yaml
+++ b/.github/workflows/reload_api.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   reload:
     name: Reload API database
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Reload API database

--- a/.github/workflows/reload_server.yaml
+++ b/.github/workflows/reload_server.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   reload:
     name: Reload server database
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Reload server database


### PR DESCRIPTION
Ubuntu 20.04 comes with AWS CLI v2, which expects payload to
be base64 encoded. This is not a fully trivial change to make
and it is easier for now to downgrade back to 18.04, while we
test out the correct fix for 20.04.