### PR TITLE
Hide some obsolete GRFs from the content download list

### DIFF
--- a/newgrf/46544e02/global.yaml
+++ b/newgrf/46544e02/global.yaml
@@ -7,3 +7,4 @@ url: "https://www.tt-forums.net/viewtopic.php?f=67&t=75348"
 tags:
 - "fiction"
 - "town names"
+archived: true

--- a/newgrf/46544e02/global.yaml
+++ b/newgrf/46544e02/global.yaml
@@ -1,6 +1,9 @@
-name: "z-ignore"
+name: "FicTown Names (Basic)"
 description: |-
-  THIS IS OBSOLETE!
+  A list of fictional cities, towns and villages. Has the Public Domain Mark to ensure it will never be unavailable to the end user.
 
-  A list of fictional cities, towns and villages.
-tags: []
+  As a courtesy to the community, the source code can be found on the listed website.
+url: "https://www.tt-forums.net/viewtopic.php?f=67&t=75348"
+tags:
+- "fiction"
+- "town names"

--- a/newgrf/46544e02/versions/20190610T000851Z.yaml
+++ b/newgrf/46544e02/versions/20190610T000851Z.yaml
@@ -3,7 +3,7 @@ license: "GPL v2"
 upload-date: 2019-06-10T00:08:51Z
 md5sum-partial: "fb70b9a1"
 filesize: 14132
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "master"
   conditions:

--- a/newgrf/46544e03/global.yaml
+++ b/newgrf/46544e03/global.yaml
@@ -1,6 +1,11 @@
-name: "z-ignore"
+name: "FicTown+ Names"
 description: |-
-  THIS IS OBSOLETE!
-
   A list of fictional cities, towns and villages. GPL v2 to ensure it will never be unavailable to the end user.
-tags: []
+
+  The Plus version includes names from fandoms (Touhou, Tabletop RPGs) and names from unpublished works contributed by creative people I have permision from, or who are in the community and ask nicely ;).
+
+  As a courtesy to the community, the source code can be found on the listed website.
+url: "https://www.tt-forums.net/viewtopic.php?f=67&t=75348"
+tags:
+- "fiction"
+- "town names"

--- a/newgrf/46544e03/global.yaml
+++ b/newgrf/46544e03/global.yaml
@@ -9,3 +9,4 @@ url: "https://www.tt-forums.net/viewtopic.php?f=67&t=75348"
 tags:
 - "fiction"
 - "town names"
+archived: true

--- a/newgrf/46544e03/versions/20190610T000826Z.yaml
+++ b/newgrf/46544e03/versions/20190610T000826Z.yaml
@@ -3,7 +3,7 @@ license: "GPL v2"
 upload-date: 2019-06-10T00:08:26Z
 md5sum-partial: "b1e8e158"
 filesize: 14382
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "master"
   conditions:

--- a/newgrf/46544e06/global.yaml
+++ b/newgrf/46544e06/global.yaml
@@ -1,8 +1,14 @@
-name: "z-ignore"
+name: "FicTown Names"
 replaced-by:
   unique-id: "46544e07"
 description: |-
-  THIS IS OBSOLETE!
+  LEGACY VERSION!
+  See "FicTown Names Basic" and "FicTown+ Names" for newer versions.
 
-  A list of fictional cities, towns and villages.
-tags: []
+  A continually-expanding list of fictional cities, towns and villages. Has the Public Domain Mark to ensure it will never be unavailable to the end user.
+
+  Additionally, as a courtesy to the community, the source code can be found on the listed website so that it can be modified and said modifications published.
+url: "https://www.tt-forums.net/viewtopic.php?f=67&t=75348"
+tags:
+- "fiction"
+- "town names"

--- a/newgrf/46544e06/global.yaml
+++ b/newgrf/46544e06/global.yaml
@@ -12,3 +12,4 @@ url: "https://www.tt-forums.net/viewtopic.php?f=67&t=75348"
 tags:
 - "fiction"
 - "town names"
+archived: true

--- a/newgrf/46544e07/global.yaml
+++ b/newgrf/46544e07/global.yaml
@@ -1,6 +1,14 @@
-name: "z-ignore"
+name: "FicTown Names"
 description: |-
-  THIS IS OBSOLETE!
+  LEGACY VERSION!
+  See "FicTown Names Basic" and "FicTown+ Names" for newer versions.
 
-  A list of fictional cities, towns and villages.
-tags: []
+  A continually-expanding list of fictional cities, towns and villages. Has the Public Domain Mark to ensure it will never be unavailable to the end user.
+
+  Additionally, as a courtesy to the community, the source code can be found on the listed website so that it can be modified and said modifications published.
+url: "https://www.tt-forums.net/viewtopic.php?f=67&t=75348"
+tags:
+- "fiction"
+- "legacy"
+- "legacy version"
+- "town names"

--- a/newgrf/46544e07/global.yaml
+++ b/newgrf/46544e07/global.yaml
@@ -1,4 +1,6 @@
 name: "FicTown Names"
+replaced-by:
+  unique-id: "46544e07"
 description: |-
   LEGACY VERSION!
   See "FicTown Names Basic" and "FicTown+ Names" for newer versions.
@@ -12,3 +14,4 @@ tags:
 - "legacy"
 - "legacy version"
 - "town names"
+archived: true

--- a/newgrf/46544e07/versions/20170820T073132Z.yaml
+++ b/newgrf/46544e07/versions/20170820T073132Z.yaml
@@ -3,7 +3,7 @@ license: "Custom"
 upload-date: 2017-08-20T07:31:32Z
 md5sum-partial: "2e494ba5"
 filesize: 6291
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "master"
   conditions:

--- a/newgrf/46544e08/global.yaml
+++ b/newgrf/46544e08/global.yaml
@@ -1,8 +1,11 @@
-name: "z-ignore"
+name: "FicTown Names (Basic)"
 replaced-by:
   unique-id: "46545015"
 description: |-
-  THIS IS OBSOLETE!
+  A continually-expanding list of fictional cities, towns and villages. Has the Public Domain Mark to ensure it will never be unavailable to the end user.
 
-  A list of fictional cities, towns and villages.
-tags: []
+  Additionally, as a courtesy to the community, the source code can be found on the listed website so that it can be modified and said modifications published.
+url: "https://www.tt-forums.net/viewtopic.php?f=67&t=75348"
+tags:
+- "fiction"
+- "town names"

--- a/newgrf/46544e08/global.yaml
+++ b/newgrf/46544e08/global.yaml
@@ -9,3 +9,4 @@ url: "https://www.tt-forums.net/viewtopic.php?f=67&t=75348"
 tags:
 - "fiction"
 - "town names"
+archived: true

--- a/newgrf/46544e16/global.yaml
+++ b/newgrf/46544e16/global.yaml
@@ -1,8 +1,13 @@
-name: "z-ignore"
+name: "FicTown+ Names"
 replaced-by:
   unique-id: "46544e17"
 description: |-
-  THIS IS OBSOLETE!
+  A continually-expanding list of fictional cities, towns and villages. Has the Public Domain Mark to ensure it will never be unavailable to the end user.
 
-  A list of fictional cities, towns and villages.
-tags: []
+  The Plus version includes names from fandoms (Touhou, Tabletop RPGs) and names from unpublished works contributed by creative people I have permision from, or who are in the community and ask nicely ;).
+
+  As a courtesy to the community, the source code can be found on the listed website.
+url: "https://www.tt-forums.net/viewtopic.php?f=67&t=75348"
+tags:
+- "fiction"
+- "town names"

--- a/newgrf/46544e16/global.yaml
+++ b/newgrf/46544e16/global.yaml
@@ -11,3 +11,4 @@ url: "https://www.tt-forums.net/viewtopic.php?f=67&t=75348"
 tags:
 - "fiction"
 - "town names"
+archived: true

--- a/newgrf/46544e17/global.yaml
+++ b/newgrf/46544e17/global.yaml
@@ -11,3 +11,4 @@ url: "https://www.tt-forums.net/viewtopic.php?f=67&t=75348"
 tags:
 - "fiction"
 - "town names"
+archived: true

--- a/newgrf/46544e17/global.yaml
+++ b/newgrf/46544e17/global.yaml
@@ -1,8 +1,13 @@
-name: "z-ignore"
+name: "FicTown+ Names"
 replaced-by:
   unique-id: "46544e03"
 description: |-
-  THIS IS OBSOLETE!
+  A list of fictional cities, towns and villages. Has the Public Domain Mark to ensure it will never be unavailable to the end user.
 
-  A list of fictional cities, towns and villages.
-tags: []
+  The Plus version includes names from fandoms (Touhou, Tabletop RPGs) and names from unpublished works contributed by creative people I have permision from, or who are in the community and ask nicely ;).
+
+  As a courtesy to the community, the source code can be found on the listed website.
+url: "https://www.tt-forums.net/viewtopic.php?f=67&t=75348"
+tags:
+- "fiction"
+- "town names"

--- a/newgrf/46545008/global.yaml
+++ b/newgrf/46545008/global.yaml
@@ -1,8 +1,13 @@
-name: "z-ignore"
+name: "FicTown+ Names"
 replaced-by:
   unique-id: "46544e16"
 description: |-
-  THIS IS OBSOLETE!
+  A continually-expanding list of fictional cities, towns and villages. Has the Public Domain Mark to ensure it will never be unavailable to the end user.
 
-  A list of fictional cities, towns and villages.
-tags: []
+  The Plus version includes names from fandoms (Touhou, Tabletop RPGs) and names from unpublished works contributed by creative people I have permision from, or who are in the community and ask nicely ;).
+
+  As a courtesy to the community, the source code can be found on the listed website.
+url: "https://www.tt-forums.net/viewtopic.php?f=67&t=75348"
+tags:
+- "fiction"
+- "town names"

--- a/newgrf/46545008/global.yaml
+++ b/newgrf/46545008/global.yaml
@@ -11,3 +11,4 @@ url: "https://www.tt-forums.net/viewtopic.php?f=67&t=75348"
 tags:
 - "fiction"
 - "town names"
+archived: true

--- a/newgrf/46545015/global.yaml
+++ b/newgrf/46545015/global.yaml
@@ -1,8 +1,8 @@
-name: "z-ignore"
+name: "FicTown Names (Basic)"
 replaced-by:
   unique-id: "46544e02"
-description: |-
-  THIS IS OBSOLETE!
-
-  Discontinued due to GRF ID and uploading issues, please see FicTownNames 2 for the only supported version.
-tags: []
+description: "Discontinued due to GRF ID and uploading issues, please see FicTown+ Names for the only supported version."
+url: "https://www.tt-forums.net/viewtopic.php?f=67&t=75348"
+tags:
+- "fiction"
+- "town names"

--- a/newgrf/46545015/global.yaml
+++ b/newgrf/46545015/global.yaml
@@ -6,3 +6,4 @@ url: "https://www.tt-forums.net/viewtopic.php?f=67&t=75348"
 tags:
 - "fiction"
 - "town names"
+archived: true

--- a/newgrf/49485101/global.yaml
+++ b/newgrf/49485101/global.yaml
@@ -1,8 +1,11 @@
-name: "z-ignore"
+name: "Iron Horse \"Quicksilver\" Add-"
 description: |-
-  THIS IS OBSOLETE!
-
-  GPL v2, coded by Gwyd. Credits to Pikkabird for Graphics.
+  GPL v2, coded by Gwyd and SimYouLater. Credits to Pikkabird and SimYouLater for Graphics.
 
   Contains a streamlined steam locomotive and several other locomotives for use with Iron Horse 2, like Electra and Cyclops.
-tags: []
+url: "https://www.tt-forums.net/viewtopic.php?f=26&t=83126"
+tags:
+- "gresley"
+- "steam"
+- "streamliner"
+- "uk"

--- a/newgrf/49485101/global.yaml
+++ b/newgrf/49485101/global.yaml
@@ -9,3 +9,4 @@ tags:
 - "steam"
 - "streamliner"
 - "uk"
+archived: true

--- a/newgrf/49485101/versions/20191023T012205Z.yaml
+++ b/newgrf/49485101/versions/20191023T012205Z.yaml
@@ -3,7 +3,7 @@ license: "GPL v2"
 upload-date: 2019-10-23T01:22:05Z
 md5sum-partial: "52fbab8a"
 filesize: 10825
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "master"
   conditions:

--- a/newgrf/49485107/global.yaml
+++ b/newgrf/49485107/global.yaml
@@ -6,3 +6,4 @@ description: |-
 
   Based on streamlined steam locomotives of the 1930's like LNER A4, NYC Mercury, etc.
 url: "https://www.tt-forums.net/viewtopic.php?f=26&t=83126"
+archived: true

--- a/newgrf/49485107/global.yaml
+++ b/newgrf/49485107/global.yaml
@@ -1,10 +1,8 @@
-name: "z-ignore"
+name: "Iron Horse \"Quicksilver\" Add-"
 replaced-by:
   unique-id: "49485101"
 description: |-
-  THIS IS OBSOLETE!
-
-  GPL v2, coded by Gwyd. Credits to Pikkabird for Graphics.
+  GPL v2, coded by Gwyd and SimYouLater. Credits to Pikkabird and SimYouLater for Graphics.
 
   Based on streamlined steam locomotives of the 1930's like LNER A4, NYC Mercury, etc.
-tags: []
+url: "https://www.tt-forums.net/viewtopic.php?f=26&t=83126"

--- a/newgrf/52495301/global.yaml
+++ b/newgrf/52495301/global.yaml
@@ -6,3 +6,4 @@ description: |-
 
   Originally meant to also include roads that didn't require NRT and were compatible with classic TTD graphics, however this is no longer possible. Licensing is dumb that way.
 url: "https://www.tt-forums.net/viewtopic.php?f=26&t=83306"
+archived: true

--- a/newgrf/52495301/global.yaml
+++ b/newgrf/52495301/global.yaml
@@ -1,10 +1,8 @@
-name: "z-ignore"
+name: "Recycled Infrastructure Set"
 replaced-by:
   unique-id: "52495302"
 description: |-
-  THIS IS OBSOLETE!
-
   A set of tram tracks with grass foundation that don't let the roads peek out from the edges.
 
   Originally meant to also include roads that didn't require NRT and were compatible with classic TTD graphics, however this is no longer possible. Licensing is dumb that way.
-tags: []
+url: "https://www.tt-forums.net/viewtopic.php?f=26&t=83306"

--- a/newgrf/52495302/global.yaml
+++ b/newgrf/52495302/global.yaml
@@ -16,3 +16,4 @@ description: |-
   Will soon include...
   + FooBar's Tram Tracks (temporarily removed for NRT compatibility)
 url: "https://www.tt-forums.net/viewtopic.php?f=26&t=83306"
+archived: true

--- a/newgrf/52495302/global.yaml
+++ b/newgrf/52495302/global.yaml
@@ -1,7 +1,5 @@
-name: "z-ignore"
+name: "Recycled Infrastructure Set"
 description: |-
-  THIS IS OBSOLETE!]
-
   A set of infrastructure aiming to include other GPL v2 graphics in one NewGRF with no graphical oddities.
 
   Thanks to...
@@ -17,4 +15,4 @@ description: |-
 
   Will soon include...
   + FooBar's Tram Tracks (temporarily removed for NRT compatibility)
-tags: []
+url: "https://www.tt-forums.net/viewtopic.php?f=26&t=83306"

--- a/newgrf/52495302/versions/20191024T184233Z.yaml
+++ b/newgrf/52495302/versions/20191024T184233Z.yaml
@@ -3,7 +3,7 @@ license: "GPL v2"
 upload-date: 2019-10-24T18:42:33Z
 md5sum-partial: "5e2d6d85"
 filesize: 246454
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "master"
   conditions:

--- a/newgrf/52495303/global.yaml
+++ b/newgrf/52495303/global.yaml
@@ -13,3 +13,4 @@ description: |-
   + FooBar's Metro Track Set
   + Snail's Dual Gauge (basis for Volos Tri-Guage, usable with 600mm, French Meter Guage and AuzRailSet)
 url: "https://www.tt-forums.net/viewtopic.php?f=26&t=83306&p=1207722#p1207722"
+archived: true

--- a/newgrf/52495303/global.yaml
+++ b/newgrf/52495303/global.yaml
@@ -1,7 +1,5 @@
-name: "z-ignore"
+name: "Recycled Infrastructure Set JGR"
 description: |-
-  THIS IS OBSOLETE!
-
   A set of infrastructure aiming to include other GPL v2 graphics in one NewGRF with no graphical oddities. Not compatible with road types!
 
   Thanks to...
@@ -14,4 +12,4 @@ description: |-
   + FooBar's Tram Tracks
   + FooBar's Metro Track Set
   + Snail's Dual Gauge (basis for Volos Tri-Guage, usable with 600mm, French Meter Guage and AuzRailSet)
-tags: []
+url: "https://www.tt-forums.net/viewtopic.php?f=26&t=83306&p=1207722#p1207722"

--- a/newgrf/52495303/versions/20190715T170204Z.yaml
+++ b/newgrf/52495303/versions/20190715T170204Z.yaml
@@ -3,7 +3,7 @@ license: "GPL v2"
 upload-date: 2019-07-15T17:02:04Z
 md5sum-partial: "f448be74"
 filesize: 301236
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "master"
   conditions:

--- a/newgrf/544f5902/global.yaml
+++ b/newgrf/544f5902/global.yaml
@@ -6,3 +6,4 @@ description: |-
 url: "https://www.tt-forums.net/viewtopic.php?f=26&t=83134"
 tags:
 - "toyland"
+archived: true

--- a/newgrf/544f5902/global.yaml
+++ b/newgrf/544f5902/global.yaml
@@ -1,3 +1,8 @@
-name: "z-ignore"
-description: "THIS IS OBSOLETE!"
-tags: []
+name: "ToyTrax"
+description: |-
+  A GPL v2 trackset designed to imitate the original TTD Toyland tracks. See URL for source code!
+
+  This version defines the tracks as a new railtype with 80 km/h normal and electrified versions.
+url: "https://www.tt-forums.net/viewtopic.php?f=26&t=83134"
+tags:
+- "toyland"

--- a/newgrf/544f5902/versions/20180808T212359Z.yaml
+++ b/newgrf/544f5902/versions/20180808T212359Z.yaml
@@ -3,7 +3,7 @@ license: "GPL v2"
 upload-date: 2018-08-08T21:23:59Z
 md5sum-partial: "63248ac0"
 filesize: 19628
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "master"
   conditions:


### PR DESCRIPTION
I saw a load of "z-ignore" GRFs in the list, which made me sad. So I've reverted those changes and marked the GRFs as "savegame-only", which removes them from the ContentDownload list while still allowing existing savegames to work, should they use them.

This behaviour isn't currently exposed through the manager, so I thought I'd fix it here.

cc @SimYouLater , for reference