### PR TITLE
Fix: [Actions] "aws lambda invoke" times out before the Lambda does

### DIFF
--- a/.github/workflows/reload_api.yaml
+++ b/.github/workflows/reload_api.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - name: Reload API database
       run: |
-        aws lambda invoke --region ${{ secrets.AWS_REGION }} --function-name "${{ secrets.API_FUNCTION_NAME }}" --payload='{"secret":"${{ secrets.API_RELOAD_SECRET }}"}' output.txt
+        aws lambda invoke --cli-read-timeout 120 --region ${{ secrets.AWS_REGION }} --function-name "${{ secrets.API_FUNCTION_NAME }}" --payload='{"secret":"${{ secrets.API_RELOAD_SECRET }}"}' output.txt
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.API_AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.API_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/reload_server.yaml
+++ b/.github/workflows/reload_server.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - name: Reload server database
       run: |
-        aws lambda invoke --region ${{ secrets.AWS_REGION }} --function-name "${{ secrets.SERVER_FUNCTION_NAME }}" --payload='{"secret":"${{ secrets.SERVER_RELOAD_SECRET }}"}' output.txt
+        aws lambda invoke --cli-read-timeout 120 --region ${{ secrets.AWS_REGION }} --function-name "${{ secrets.SERVER_FUNCTION_NAME }}" --payload='{"secret":"${{ secrets.SERVER_RELOAD_SECRET }}"}' output.txt
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.SERVER_AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.SERVER_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This is some serious weird behaviour right here. The Lambda called
is on a 120 second timeout. Over the months the Lambda has grown
from ~50 seconds to ~65 seconds to finish. Lately it keps on failing,
but the Lambda indicated it executed successful.

Welllllll .. the aws CLI has its own timeout, completely unrelated
to the Lambda, which by default is set ot 60 seconds. They do not
want to change that, "as people might be depending on this behaviour
now". So instead we all one by one have to run into this problem,
and in the end when we figure out what was causing it, can only go:

*FACEPALM*

Right, enough of a rant here. Make sure the aws CLI timeout is
equal to the Lambda we are using. This should prevent the Action
failing where the Lambda doesn't.