### PR TITLE
Fix: NewGRF 50545453 has an upper-version-limit which is most likely not intentional

### DIFF
--- a/newgrf/50545453/versions/20200710T224129Z.yaml
+++ b/newgrf/50545453/versions/20200710T224129Z.yaml
@@ -8,4 +8,3 @@ compatibility:
 - name: "official"
   conditions:
   - ">= 1.9.3"
-  - "< 2.0.0"


### PR DESCRIPTION
@joaogenio: we are looking into using OpenTTD versions higher than 1.X.X (for example, 12.0 for our next release). Your content has a constraint that the NewGRF doesn't work for versions above 2.0.0. I think this is unintentional. If so, I would like to fix this for you, but of course, only after confirming with you :)

So in short: am I correct to assume the upper-version-limit for `PTTS - Portuguese Trainset` was not intentional?

Tnx!