### PR TITLE
Fix: hide all NewGRFs from theoldtier, to unclog the NewGRF listing 

### DIFF
--- a/newgrf/54303043/versions/20220509T033413Z.yaml
+++ b/newgrf/54303043/versions/20220509T033413Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T03:34:13Z
 md5sum-partial: "f340049e"
 filesize: 7638
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54303143/versions/20220509T034620Z.yaml
+++ b/newgrf/54303143/versions/20220509T034620Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T03:46:20Z
 md5sum-partial: "11be5aab"
 filesize: 7642
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54303243/versions/20220509T034827Z.yaml
+++ b/newgrf/54303243/versions/20220509T034827Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T03:48:27Z
 md5sum-partial: "e96ebfb1"
 filesize: 7642
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54303343/versions/20220509T035001Z.yaml
+++ b/newgrf/54303343/versions/20220509T035001Z.yaml
@@ -3,4 +3,4 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T03:50:01Z
 md5sum-partial: "242b570e"
 filesize: 7642
-availability: "new-games"
+availability: "savegames-only"

--- a/newgrf/54303443/versions/20220509T035027Z.yaml
+++ b/newgrf/54303443/versions/20220509T035027Z.yaml
@@ -3,4 +3,4 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T03:50:27Z
 md5sum-partial: "69919952"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"

--- a/newgrf/54303543/versions/20220509T035201Z.yaml
+++ b/newgrf/54303543/versions/20220509T035201Z.yaml
@@ -3,4 +3,4 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T03:52:01Z
 md5sum-partial: "498f0590"
 filesize: 7645
-availability: "new-games"
+availability: "savegames-only"

--- a/newgrf/54303643/versions/20220509T035220Z.yaml
+++ b/newgrf/54303643/versions/20220509T035220Z.yaml
@@ -3,4 +3,4 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T03:52:20Z
 md5sum-partial: "603c5a71"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"

--- a/newgrf/54303743/versions/20220509T035251Z.yaml
+++ b/newgrf/54303743/versions/20220509T035251Z.yaml
@@ -3,4 +3,4 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T03:52:51Z
 md5sum-partial: "df9a2220"
 filesize: 7643
-availability: "new-games"
+availability: "savegames-only"

--- a/newgrf/54303843/versions/20220509T035317Z.yaml
+++ b/newgrf/54303843/versions/20220509T035317Z.yaml
@@ -3,4 +3,4 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T03:53:17Z
 md5sum-partial: "248cae1c"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"

--- a/newgrf/54303943/versions/20220509T035423Z.yaml
+++ b/newgrf/54303943/versions/20220509T035423Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T03:54:23Z
 md5sum-partial: "2f7d95b6"
 filesize: 7643
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54313043/versions/20220509T035437Z.yaml
+++ b/newgrf/54313043/versions/20220509T035437Z.yaml
@@ -3,4 +3,4 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T03:54:37Z
 md5sum-partial: "d606bccc"
 filesize: 7642
-availability: "new-games"
+availability: "savegames-only"

--- a/newgrf/54313143/versions/20220509T035812Z.yaml
+++ b/newgrf/54313143/versions/20220509T035812Z.yaml
@@ -3,4 +3,4 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T03:58:12Z
 md5sum-partial: "b564d374"
 filesize: 7641
-availability: "new-games"
+availability: "savegames-only"

--- a/newgrf/54313243/versions/20220509T042737Z.yaml
+++ b/newgrf/54313243/versions/20220509T042737Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:27:37Z
 md5sum-partial: "83347325"
 filesize: 7645
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54313343/versions/20220509T042800Z.yaml
+++ b/newgrf/54313343/versions/20220509T042800Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:28:00Z
 md5sum-partial: "c8120cc9"
 filesize: 7641
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54313443/versions/20220509T042857Z.yaml
+++ b/newgrf/54313443/versions/20220509T042857Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:28:57Z
 md5sum-partial: "e0744a08"
 filesize: 7641
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54313543/versions/20220509T042929Z.yaml
+++ b/newgrf/54313543/versions/20220509T042929Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:29:29Z
 md5sum-partial: "4a1aab85"
 filesize: 7641
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54313643/versions/20220509T042945Z.yaml
+++ b/newgrf/54313643/versions/20220509T042945Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:29:45Z
 md5sum-partial: "07794eaa"
 filesize: 7641
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54313743/versions/20220509T043000Z.yaml
+++ b/newgrf/54313743/versions/20220509T043000Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:30:00Z
 md5sum-partial: "8f0b04d0"
 filesize: 7646
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54313843/versions/20220509T043020Z.yaml
+++ b/newgrf/54313843/versions/20220509T043020Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:30:20Z
 md5sum-partial: "065830a8"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54313943/versions/20220509T043045Z.yaml
+++ b/newgrf/54313943/versions/20220509T043045Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:30:45Z
 md5sum-partial: "101dddd1"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54323043/versions/20220509T043147Z.yaml
+++ b/newgrf/54323043/versions/20220509T043147Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:31:47Z
 md5sum-partial: "266a70ae"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54323143/versions/20220509T043203Z.yaml
+++ b/newgrf/54323143/versions/20220509T043203Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:32:03Z
 md5sum-partial: "27f49e77"
 filesize: 7643
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54323243/versions/20220509T043219Z.yaml
+++ b/newgrf/54323243/versions/20220509T043219Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:32:19Z
 md5sum-partial: "974cf64a"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54323343/versions/20220509T043233Z.yaml
+++ b/newgrf/54323343/versions/20220509T043233Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:32:33Z
 md5sum-partial: "e2ebef65"
 filesize: 7642
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54323443/versions/20220509T043302Z.yaml
+++ b/newgrf/54323443/versions/20220509T043302Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:33:02Z
 md5sum-partial: "0557ff4a"
 filesize: 7640
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54323543/versions/20220509T043319Z.yaml
+++ b/newgrf/54323543/versions/20220509T043319Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:33:19Z
 md5sum-partial: "ba44f5ae"
 filesize: 7645
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54323643/versions/20220509T043336Z.yaml
+++ b/newgrf/54323643/versions/20220509T043336Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:33:36Z
 md5sum-partial: "39caa278"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54323743/versions/20220509T043353Z.yaml
+++ b/newgrf/54323743/versions/20220509T043353Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:33:53Z
 md5sum-partial: "f6c61d4b"
 filesize: 7645
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54323843/versions/20220509T043412Z.yaml
+++ b/newgrf/54323843/versions/20220509T043412Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:34:12Z
 md5sum-partial: "56033a11"
 filesize: 7646
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54323943/versions/20220509T043427Z.yaml
+++ b/newgrf/54323943/versions/20220509T043427Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:34:27Z
 md5sum-partial: "40d41f47"
 filesize: 7646
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54333043/versions/20220509T043453Z.yaml
+++ b/newgrf/54333043/versions/20220509T043453Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:34:53Z
 md5sum-partial: "492c5866"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54333143/versions/20220509T043514Z.yaml
+++ b/newgrf/54333143/versions/20220509T043514Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:35:14Z
 md5sum-partial: "a05e3ee5"
 filesize: 7642
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54333243/versions/20220509T043529Z.yaml
+++ b/newgrf/54333243/versions/20220509T043529Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:35:29Z
 md5sum-partial: "dc5c8017"
 filesize: 7643
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54333343/versions/20220509T043543Z.yaml
+++ b/newgrf/54333343/versions/20220509T043543Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:35:43Z
 md5sum-partial: "563b063b"
 filesize: 7647
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54333443/versions/20220509T043559Z.yaml
+++ b/newgrf/54333443/versions/20220509T043559Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:35:59Z
 md5sum-partial: "148e29bd"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54333543/versions/20220509T043817Z.yaml
+++ b/newgrf/54333543/versions/20220509T043817Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:38:17Z
 md5sum-partial: "62160f69"
 filesize: 7645
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54333643/versions/20220509T043833Z.yaml
+++ b/newgrf/54333643/versions/20220509T043833Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:38:33Z
 md5sum-partial: "d8ea9366"
 filesize: 7645
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54333743/versions/20220509T043850Z.yaml
+++ b/newgrf/54333743/versions/20220509T043850Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:38:50Z
 md5sum-partial: "72b2109b"
 filesize: 7643
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54333843/versions/20220509T043909Z.yaml
+++ b/newgrf/54333843/versions/20220509T043909Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:39:09Z
 md5sum-partial: "6d838300"
 filesize: 7645
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54333943/versions/20220509T043935Z.yaml
+++ b/newgrf/54333943/versions/20220509T043935Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:39:35Z
 md5sum-partial: "7c2c967d"
 filesize: 7641
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54343043/versions/20220509T043952Z.yaml
+++ b/newgrf/54343043/versions/20220509T043952Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:39:52Z
 md5sum-partial: "ebe2fb21"
 filesize: 7640
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54343143/versions/20220509T044008Z.yaml
+++ b/newgrf/54343143/versions/20220509T044008Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:40:08Z
 md5sum-partial: "9a4964dc"
 filesize: 7643
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54343243/versions/20220509T044028Z.yaml
+++ b/newgrf/54343243/versions/20220509T044028Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:40:28Z
 md5sum-partial: "ead74fee"
 filesize: 7642
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54343343/versions/20220509T044045Z.yaml
+++ b/newgrf/54343343/versions/20220509T044045Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:40:45Z
 md5sum-partial: "e0da51a6"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54343443/versions/20220509T044333Z.yaml
+++ b/newgrf/54343443/versions/20220509T044333Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:43:33Z
 md5sum-partial: "92a0ec33"
 filesize: 7643
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54343543/versions/20220509T044439Z.yaml
+++ b/newgrf/54343543/versions/20220509T044439Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:44:39Z
 md5sum-partial: "bdae4b35"
 filesize: 7643
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54343643/versions/20220509T044517Z.yaml
+++ b/newgrf/54343643/versions/20220509T044517Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:45:17Z
 md5sum-partial: "bd6e8442"
 filesize: 7643
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54343743/versions/20220509T044650Z.yaml
+++ b/newgrf/54343743/versions/20220509T044650Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:46:50Z
 md5sum-partial: "c6e59827"
 filesize: 7645
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54343843/versions/20220509T044714Z.yaml
+++ b/newgrf/54343843/versions/20220509T044714Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:47:14Z
 md5sum-partial: "eefc9464"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54343943/versions/20220509T044738Z.yaml
+++ b/newgrf/54343943/versions/20220509T044738Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:47:38Z
 md5sum-partial: "b08af140"
 filesize: 7645
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54353043/versions/20220509T044830Z.yaml
+++ b/newgrf/54353043/versions/20220509T044830Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:48:30Z
 md5sum-partial: "7e040494"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54353143/versions/20220509T044854Z.yaml
+++ b/newgrf/54353143/versions/20220509T044854Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:48:54Z
 md5sum-partial: "fea9b0c3"
 filesize: 7643
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54353243/versions/20220509T045033Z.yaml
+++ b/newgrf/54353243/versions/20220509T045033Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:50:33Z
 md5sum-partial: "ba20ffcc"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54353343/versions/20220509T045134Z.yaml
+++ b/newgrf/54353343/versions/20220509T045134Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:51:34Z
 md5sum-partial: "f0f266aa"
 filesize: 7645
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54353443/versions/20220509T045153Z.yaml
+++ b/newgrf/54353443/versions/20220509T045153Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:51:53Z
 md5sum-partial: "629e46ba"
 filesize: 7645
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54353543/versions/20220509T045611Z.yaml
+++ b/newgrf/54353543/versions/20220509T045611Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:56:11Z
 md5sum-partial: "42eb1d26"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54353643/versions/20220509T045628Z.yaml
+++ b/newgrf/54353643/versions/20220509T045628Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:56:28Z
 md5sum-partial: "2cdc7c34"
 filesize: 7645
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54353743/versions/20220509T045651Z.yaml
+++ b/newgrf/54353743/versions/20220509T045651Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T04:56:51Z
 md5sum-partial: "01971a95"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54353843/versions/20220509T050218Z.yaml
+++ b/newgrf/54353843/versions/20220509T050218Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T05:02:18Z
 md5sum-partial: "5af5fdbe"
 filesize: 7646
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54353943/versions/20220509T050238Z.yaml
+++ b/newgrf/54353943/versions/20220509T050238Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T05:02:38Z
 md5sum-partial: "db03b362"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54363043/versions/20220509T050256Z.yaml
+++ b/newgrf/54363043/versions/20220509T050256Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T05:02:56Z
 md5sum-partial: "8bad025e"
 filesize: 7644
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54363143/versions/20220509T050313Z.yaml
+++ b/newgrf/54363143/versions/20220509T050313Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T05:03:13Z
 md5sum-partial: "c1780d46"
 filesize: 7645
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54363243/versions/20220509T050335Z.yaml
+++ b/newgrf/54363243/versions/20220509T050335Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T05:03:35Z
 md5sum-partial: "93ab8aff"
 filesize: 7647
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:

--- a/newgrf/54363343/versions/20220509T050352Z.yaml
+++ b/newgrf/54363343/versions/20220509T050352Z.yaml
@@ -3,7 +3,7 @@ license: "CC-BY-NC-ND v3.0"
 upload-date: 2022-05-09T05:03:52Z
 md5sum-partial: "598b0c6e"
 filesize: 7640
-availability: "new-games"
+availability: "savegames-only"
 compatibility:
 - name: "jgrpp"
   conditions:


### PR DESCRIPTION
These are very small NewGRFs, 1 for each cargo type, and it is meant
to be used with scenarios. It allows fine control over payment for every
cargo-type.
Putting it into a single NewGRF is not possible, as the parameter limit
kicks in. So this is the best solution the user came up with.

By making them savegame-only, we hide it for most people, while
those that want it can get the files.