### PR TITLE
Fix: versions in conditions for 4A460200 and 5F5F0200 are invalid

### DIFF
--- a/newgrf/4a460200/versions/20221209T064009Z.yaml
+++ b/newgrf/4a460200/versions/20221209T064009Z.yaml
@@ -10,6 +10,6 @@ compatibility:
   - ">= 1.10.0"
 - name: "jgrpp"
   conditions:
-  - ">= 0.32 - rc1"
+  - ">= 0.32.0"
 
 description: "*THIS GRF IS OBSOLETE*"

--- a/newgrf/5f5f0200/versions/20221210T075746Z.yaml
+++ b/newgrf/5f5f0200/versions/20221210T075746Z.yaml
@@ -10,4 +10,4 @@ compatibility:
   - ">= 1.10.0"
 - name: "jgrpp"
   conditions:
-  - ">= 0.32 - rc1"
+  - ">= 0.32.0"


### PR DESCRIPTION
This caused bananas-server to bail out on loading this database.