### PR TITLE
Remove: 'Highspeed Trains' due to violations.

### DIFF
--- a/newgrf/4b480800/authors.yaml
+++ b/newgrf/4b480800/authors.yaml
@@ -1,3 +1,0 @@
-authors:
-- display-name: "ken1233kh"
-  github: "33641127"

--- a/newgrf/4b480800/global.yaml
+++ b/newgrf/4b480800/global.yaml
@@ -1,6 +1,1 @@
-name: "Highspeed Trains"
-description: "This is the train, tram and car objects required for the Highspeed Tracks"
-tags:
-- "Road"
-- "Trains"
-- "Trams"
+blacklisted: true

--- a/newgrf/4b480800/versions/20221207T064542Z.yaml
+++ b/newgrf/4b480800/versions/20221207T064542Z.yaml
@@ -1,6 +1,0 @@
-version: "1"
-license: "GPL v2"
-upload-date: 2022-12-07T06:45:42Z
-md5sum-partial: "6b17b95c"
-filesize: 3791035
-availability: "new-games"


### PR DESCRIPTION
We received a request to remove `newgrf/4b480800` "Highspeed Trains" due to copyright violations.
Presumably the NewGRF contains multiple train graphics from `newgrf/44440000` "Pineapple Trains" without permission or license granted.

@ken1233kh, please comment on the allegation and/or resolve the issue with @PikkaBird, the author of "Pineapple Trains"; otherwise we are forced to remove "Highspeed Trains" on Monday 2023-01-09.
