### PR TITLE
Change: add 'qamil95' and 'Brickblock1' as co-authors to Polish Train Set

### DIFF
--- a/newgrf/4d560103/authors.yaml
+++ b/newgrf/4d560103/authors.yaml
@@ -1,3 +1,7 @@
 authors:
 - display-name: "Mevva"
   github: "81073474"
+- display-name: "qamil95"
+  github: "19841000"
+- display-name: "Brickblock1"
+  github: "100433052"


### PR DESCRIPTION
Lore:
* Started as [Pollsh PKP Set 2.0](https://bananas.openttd.org/package/newgrf/54440103) by TadeuszD in 2011. Last version on Bananas from 2017-01.
* Forked as [Polish Train Set](https://bananas.openttd.org/package/newgrf/4d560103) by @Mevva in 2021 under new GRFID. Last version on Bananas from 2021-07.
* New additions by @Brickblock1 and @qamil95 in 2022.

qamil95 asks to be added as co-author to the existing "Polish Train Set" by @Mevva, so they can publish new versions for the content.

If you all like each other, this can be done.
If you hate each others' guts, please create separate packages for your forks.
