### PR TITLE
Change: add 'kamnet' as maintainer for the BaNaNaS upload of BSPI.

### DIFF
--- a/newgrf/42580002/authors.yaml
+++ b/newgrf/42580002/authors.yaml
@@ -1,3 +1,5 @@
 authors:
 - display-name: "Borg"
   openttd: "Borg"
+- display-name: "kamnet"
+  github: "32113649"


### PR DESCRIPTION
The author wants to stay away from GH, but is fine with delegating uploading to kamnet.