### PR TITLE
Change: hide duplicated entries

### DIFF
--- a/heightmap/0000197b/versions/20230517T192707Z.yaml
+++ b/heightmap/0000197b/versions/20230517T192707Z.yaml
@@ -7,4 +7,4 @@ classification:
   resolution: "high"
   terrain-type: "hilly"
 filesize: 1441108
-availability: "new-games"
+availability: "savegames-only"

--- a/heightmap/0000197c/versions/20230517T192937Z.yaml
+++ b/heightmap/0000197c/versions/20230517T192937Z.yaml
@@ -7,4 +7,4 @@ classification:
   resolution: "high"
   terrain-type: "hilly"
 filesize: 1441105
-availability: "new-games"
+availability: "savegames-only"


### PR DESCRIPTION
#134 marked the duplicated entries as deprecated, but they are still visible. This PR marks the versions as "savegames-only" as well.