### PR TITLE
Change: put the violation suggestion in the README

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,0 @@
-blank_issues_enabled: true
-contact_links:
-- name: Copyright infringement?
-  url: https://bananas.openttd.org/manager/tos
-  about: Please report violations to abuse@openttd.org. Ideally by the copyright holder, and at least including links and references so we can verify the violation.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ It works together with [bananas-api](https://github.com/OpenTTD/bananas-api), wh
 See [introduction.md](https://github.com/OpenTTD/bananas-api/tree/master/docs/introduction.md) for more documentation about the different BaNaNaS components and how they work together.
 
 **NOTE**: to make changes to your BaNaNaS content, use [the website](https://bananas.openttd.org); do not use Pull Requests for this purpose.
+
+## Copyright infringement
+
+Please report violations to [abuse@openttd.org](mailto:abuse@openttd.org).
+Ideally it is reported by the copyright holder, and at least including links and references so we can verify the violation.


### PR DESCRIPTION
Turns out, GitHub does not render the custom issue selector if there are no custom issue templates.